### PR TITLE
Refill history

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -140,6 +140,20 @@ export const updateOrderStatus = () => (dispatch, getState) => {
   }
 }
 
+const prefillNumber = number => (dispatch, getState) => {
+  const parsedNumber = number.indexOf('+') > -1
+    && parse(number);
+
+  if (parsedNumber && parsedNumber.country) {
+    // Set country and number
+    dispatch(setCountry(parsedNumber.country));
+    dispatch(setNumber(format(parsedNumber,  'International')));
+  } else {
+    // Set only number
+    dispatch(setNumber(number));
+  }
+}
+
 export const init = options => (dispatch, getState) => {
   const inventoryPromise = dispatch(loadInventory());
   dispatch(updateOrderStatus());
@@ -151,19 +165,15 @@ export const init = options => (dispatch, getState) => {
   if (!number && defaultNumber) {
     // Try to auto detect country
     inventoryPromise.then(() => {
-      const parsedNumber = defaultNumber.indexOf('+') > -1
-        && parse(defaultNumber);
-
-      if (parsedNumber && parsedNumber.country) {
-        // Set country and number
-        dispatch(setCountry(parsedNumber.country));
-        dispatch(setNumber(format(parsedNumber,  'International')));
-      } else {
-        // Set only number
-        dispatch(setNumber(defaultNumber));
-      }
+      dispatch(prefillNumber(defaultNumber));
     });
   } else if (!number) {
     dispatch(lookupLocation());
   }
+}
+
+export const useRecentRefill = recentRefill => dispatch => {
+  dispatch(prefillNumber(recentRefill.number));
+  dispatch(setOperator(recentRefill.operator));
+  dispatch(setStep(3));
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -174,6 +174,12 @@ export const init = options => (dispatch, getState) => {
 
 export const useRecentRefill = recentRefill => dispatch => {
   dispatch(prefillNumber(recentRefill.number));
-  dispatch(setOperator(recentRefill.operator));
-  dispatch(setStep(3));
+  if (recentRefill.operator) {
+    dispatch(setOperator(recentRefill.operator));
+    dispatch(setStep(3));
+  } else {
+    dispatch(lookupNumber(recentRefill.number)).then(
+      () => dispatch(setStep(3)),
+      () => dispatch(setStep(2)));
+  }
 }

--- a/src/components/Steps/Country/RecentRefills.js
+++ b/src/components/Steps/Country/RecentRefills.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import styled from 'styled-components';
+import { parse, format } from 'libphonenumber-js';
+import { useRecentRefill } from '../../../actions';
+import { selectInventory } from '../../../store/inventory';
+
+const mapStateToProps = (state, { history }) => {
+  const inventory = selectInventory(state).result;
+
+  const items = history.reduce(
+    (acc, refill) => {
+      const parsedNumber = parse(refill.number);
+      const { country } = parsedNumber;
+
+      if (
+        (country in inventory && refill.operator in inventory[country].operators)
+      ) {
+        acc.push({
+          ...refill,
+          number: format(parsedNumber, 'International'),
+          operatorName: inventory[country].operators[refill.operator].name
+        });
+      }
+
+      return acc;
+    },
+    []
+  );
+
+  return { items };
+};
+
+const ButtonContainer = styled.div`
+  display: flex;
+`;
+
+const RefillButton = styled.a`
+  display: block;
+  padding: 4px 12px;
+  background-color: rgba(0,0,0,0.08);
+  border-radius: 16px;
+  border: 1px solid rgba(0,0,0,0.08);
+  margin-right: 8px;
+`;
+
+const RefillNumber = styled.strong`
+  display: block;
+  margin-bottom: 2px;
+`;
+const RefillOperator = styled.span`
+  font-size: 12px;
+`;
+
+const RecentRefills = ({ items, useRecentRefill }) => (
+  <div>
+    <h3>Recent refills</h3>
+    <ButtonContainer>
+      {items.map(refill => (
+        <RefillButton onClick={() => useRecentRefill(refill)} key={refill.number}>
+          <RefillNumber>{refill.number}</RefillNumber>
+          {/*<RefillOperator>{refill.operatorName}</RefillOperator>*/}
+        </RefillButton>
+      ))}
+    </ButtonContainer>
+  </div>
+);
+
+export default connect(mapStateToProps, { useRecentRefill })(RecentRefills);

--- a/src/components/Steps/Country/RecentRefills.js
+++ b/src/components/Steps/Country/RecentRefills.js
@@ -9,18 +9,23 @@ const mapStateToProps = (state, { history }) => {
   const inventory = selectInventory(state).result;
 
   const items = history.reduce(
-    (acc, refill) => {
-      const parsedNumber = parse(refill.number);
-      const { country } = parsedNumber;
+    (acc, { number, operator }) => {
+      const { country } = parse(number);
 
-      if (
-        (country in inventory && refill.operator in inventory[country].operators)
-      ) {
-        acc.push({
-          ...refill,
-          number: format(parsedNumber, 'International'),
-          operatorName: inventory[country].operators[refill.operator].name
-        });
+      if (country in inventory) {
+        const formattedNumber = format(number, 'International');
+
+        if (operator && operator in inventory[country].operators) {
+          acc.push({
+            operator,
+            number: formattedNumber
+          });
+        } else {
+          // Allow refill history with invalid/without operator
+          acc.push({
+            number: formattedNumber
+          });
+        }
       }
 
       return acc;
@@ -33,6 +38,7 @@ const mapStateToProps = (state, { history }) => {
 
 const ButtonContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
 `;
 
 const RefillButton = styled.a`
@@ -42,15 +48,10 @@ const RefillButton = styled.a`
   border-radius: 16px;
   border: 1px solid rgba(0,0,0,0.08);
   margin-right: 8px;
+  margin-bottom: 4px;
 `;
 
-const RefillNumber = styled.strong`
-  display: block;
-  margin-bottom: 2px;
-`;
-const RefillOperator = styled.span`
-  font-size: 12px;
-`;
+const RefillNumber = styled.strong``;
 
 const RecentRefills = ({ items, useRecentRefill }) => (
   <div>
@@ -59,7 +60,6 @@ const RecentRefills = ({ items, useRecentRefill }) => (
       {items.map(refill => (
         <RefillButton onClick={() => useRecentRefill(refill)} key={refill.number}>
           <RefillNumber>{refill.number}</RefillNumber>
-          {/*<RefillOperator>{refill.operatorName}</RefillOperator>*/}
         </RefillButton>
       ))}
     </ButtonContainer>

--- a/src/components/Steps/Country/index.js
+++ b/src/components/Steps/Country/index.js
@@ -6,6 +6,8 @@ import Step from '../Step';
 import Field from '../../UI/Field';
 import Button from '../../UI/Button';
 import Select from '../../UI/Select';
+import Spinner from '../../UI/Spinner';
+import RecentRefills from './RecentRefills';
 
 import {setCountry} from '../../../actions';
 import {selectCountryList, selectCountry} from '../../../store';
@@ -27,7 +29,8 @@ class CountryStep extends Component {
       onBack,
       showSummary,
       selectedCountry,
-      step
+      step,
+      refillHistory
     } = this.props;
 
     const stepProps = {
@@ -38,7 +41,9 @@ class CountryStep extends Component {
       onBack
     };
 
-    if (expanded) {
+    if (!this.props.countries || !this.props.countries.length) {
+      return <Spinner />
+    } else if (expanded) {
       return (
         <Step {...stepProps} onSubmit={() => selectedCountry && onContinue()}>
           <CountryField
@@ -54,6 +59,7 @@ class CountryStep extends Component {
               Continue
             </Button>
           </CountryField>
+          {refillHistory && <RecentRefills history={refillHistory} />}
         </Step>
       );
 

--- a/src/components/UI/PhoneNumberInput.js
+++ b/src/components/UI/PhoneNumberInput.js
@@ -41,13 +41,19 @@ class PhoneNumberInput extends Component {
     return country ? country.countryCallingCodes[0] : undefined;
   }
 
+  getAlpha2 = () => {
+    const { country={} } = this.props;
+    const { alpha2=null } = country;
+    return alpha2;
+  }
+
   formatDefaultValue = () => {
     let { defaultValue = '' } = this.props;
 
     const cc = this.getCountryCode();
+    const alpha2 = this.getAlpha2();
     const number = defaultValue.replace(/[^\d\+]/, '');
     const validNumber = this.validateNumber(number);
-    const { country: { alpha2 } } = this.props;
 
     defaultValue = validNumber
       ? format(validNumber, alpha2, 'International')
@@ -58,7 +64,7 @@ class PhoneNumberInput extends Component {
 
   validateNumber = (number) => {
     const cc = this.getCountryCode();
-    const {country: { alpha2 }} = this.props;
+    const alpha2 = this.getAlpha2();
 
     if (!number) {
       return null;

--- a/src/components/Widget.js
+++ b/src/components/Widget.js
@@ -9,7 +9,7 @@ import PackageStep from './Steps/Package';
 import OrderStep from './Steps/Order';
 
 import {init, setStep} from '../actions';
-import {selectCurrentStep} from '../store';
+import {selectCurrentStep, selectRecentNumbers} from '../store';
 
 const steps = [{
   component: CountryStep
@@ -39,10 +39,16 @@ class AirfillWidget extends Component {
       requireAccountBalance=false,
       showBTCAddress=this.props.billingCurrency === 'XBT',
       billingCurrency='XBT',
-      orderOptions={}
+      orderOptions={},
+      refillHistory=null,
+      recentNumbers
     } = this.props;
 
     const showEmailField = !orderOptions.email || orderOptions.email.indexOf('@') < 1;
+
+    const history = refillHistory
+      ? refillHistory
+      : recentNumbers.length ? recentNumbers : null;
 
     return steps.map(({component, options}, i) => {
       const Component = component;
@@ -66,6 +72,7 @@ class AirfillWidget extends Component {
         accountBalance={accountBalance}
         requireAccountBalance={requireAccountBalance}
         showEmailField={showEmailField}
+        refillHistory={history}
       />;
     })
   }
@@ -102,7 +109,8 @@ class AirfillWidget extends Component {
 }
 
 export default connect(state => ({
-  currentStep: selectCurrentStep(state)
+  currentStep: selectCurrentStep(state),
+  recentNumbers: selectRecentNumbers(state)
 }), {
   init,
   setStep

--- a/src/index.html
+++ b/src/index.html
@@ -123,6 +123,12 @@
           <td>Show BTC payment address and instructions (default: false)</td>
         </tr>
         <tr>
+          <td>refillHistory</td>
+          <td>array</td>
+          <td>no</td>
+          <td>Array of objects with shape <code>{ number, operator }</code> shown under "Recent Refills" in step 1. Overrides the history kept by the widget itself. (default: null)</td>
+        </tr>
+        <tr>
           <td>refundAddress</td>
           <td>string</td>
           <td>no</td>

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -3,7 +3,7 @@
 // With Redux, the actual stores are in /reducers.
 
 import { createStore, compose, applyMiddleware } from 'redux';
-import { persistStore, autoRehydrate } from 'redux-persist';
+import { persistStore } from 'redux-persist';
 import thunk from 'redux-thunk';
 import rootReducer from './index';
 
@@ -15,7 +15,6 @@ export default function configureStore(initialState) {
     initialState,
     compose(
       applyMiddleware(thunk),
-      autoRehydrate(),
       (process.env.NODE_ENV !== 'production' && window.devToolsExtension) ?
         window.devToolsExtension() : f => f // add support for Redux dev tools
     )

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,6 +11,7 @@ import paymentStatus, { selectPaymentStatus } from './paymentStatus';
 import inventory, { selectCountry, selectCountryList, selectAvailableOperators, selectSelectedOperator } from './inventory';
 import operator, { selectOperator } from './operator';
 import order, { selectOrder } from './order';
+import recentNumbers, { selectRecentNumbers } from './recentNumbers';
 
 // Export the reducer for use within other redux apps
 export const airfillWidget = combineReducers({
@@ -19,7 +20,8 @@ export const airfillWidget = combineReducers({
   operator,
   numberLookup,
   paymentStatus,
-  order
+  order,
+  recentNumbers
 });
 
 // Keep the same state shape when using the standalone widget
@@ -49,5 +51,8 @@ export {
   selectPaymentStatus,
 
   // Order
-  selectOrder
+  selectOrder,
+
+  // Recent numbers
+  selectRecentNumbers
 }

--- a/src/store/recentNumbers.js
+++ b/src/store/recentNumbers.js
@@ -1,6 +1,7 @@
-import {REHYDRATE} from 'redux-persist/constants';
+import { REHYDRATE } from 'redux-persist/constants';
 
-export const selectRecentNumbers = state => state.airfillWidget.recentNumbers;
+export const selectRecentNumbers = state =>
+  state.airfillWidget && state.airfillWidget.recentNumbers;
 
 export default (state = [], { type, payload }) => {
   switch (type) {
@@ -23,7 +24,10 @@ export default (state = [], { type, payload }) => {
       );
 
     case REHYDRATE:
-      return selectRecentNumbers(payload);
+      return [
+        ...state,
+        ...selectRecentNumbers(payload)
+      ];
 
     default:
       return state;

--- a/src/store/recentNumbers.js
+++ b/src/store/recentNumbers.js
@@ -1,0 +1,31 @@
+import {REHYDRATE} from 'redux-persist/constants';
+
+export const selectRecentNumbers = state => state.airfillWidget.recentNumbers;
+
+export default (state = [], { type, payload }) => {
+  switch (type) {
+    case 'LOAD_ORDER_SUCCESS':
+      const { number } = payload;
+      // Make sure number starts with +
+      const formattedNumber = number.indexOf('+') === 0 ? number : `+${number}`;
+      return state.reduce(
+        (numbers, cur) => {
+          if (
+            numbers.length < 5 &&
+            !numbers.find(refill => refill.number === cur.number)
+          ) {
+            numbers.push(cur);
+          }
+
+          return numbers;
+        },
+        [{ number: formattedNumber, operator: payload.operator }]
+      );
+
+    case REHYDRATE:
+      return selectRecentNumbers(payload);
+
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
![screen shot 2017-04-24 at 15 57 36](https://cloud.githubusercontent.com/assets/7252803/25340717/dffcd04e-2906-11e7-892d-45151deaa099.png)
The widget stores the 5 most recent refills (unique numbers) for easy access. You can also use the refillHistory prop on the widget to override this list from another source.