### PR TITLE
Standalone

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,5 @@ config/
 src/
 .editorconfig
 *.js
-
+!dist/widget.js
+circle.yml

--- a/config/base.js
+++ b/config/base.js
@@ -9,7 +9,7 @@ module.exports = {
   devtool: 'none',
   output: {
     path: path.join(__dirname, '/../dist'),
-    filename: 'widget.js',
+    filename: 'index.js',
     publicPath: publicPath,
     library: 'airfill-widget',
     libraryTarget: 'umd'

--- a/config/dev.js
+++ b/config/dev.js
@@ -6,6 +6,8 @@ const path = require('path');
 const webpack = require('webpack');
 const baseConfig = require('./base');
 
+baseConfig.output.filename = 'widget.js';
+
 const config = Object.assign({}, baseConfig, {
   entry: [
     'webpack-dev-server/client?http://127.0.0.1:' + baseConfig.devServer.port,

--- a/config/dist.js
+++ b/config/dist.js
@@ -18,7 +18,11 @@ const config = Object.assign({}, baseConfig, {
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.AggressiveMergingPlugin(),
     new webpack.NoEmitOnErrorsPlugin()
-  ]
+  ],
+  externals: {
+    'react': 'react',
+    'react-dom': 'react-dom'
+  }
 });
 
 module.exports = config;

--- a/config/dist.js
+++ b/config/dist.js
@@ -21,7 +21,9 @@ const config = Object.assign({}, baseConfig, {
   ],
   externals: {
     'react': 'react',
-    'react-dom': 'react-dom'
+    'react-dom': 'react-dom',
+    'pusher-js': 'pusher-js',
+    'libphonenumber-js': 'libphonenumber-js'
   }
 });
 

--- a/config/standalone.js
+++ b/config/standalone.js
@@ -7,7 +7,7 @@ const distConfig = require('./dist');
 const config = Object.assign({}, distConfig, {
   output: {
     path: path.join(__dirname, '/../dist'),
-    filename: 'standalone.js',
+    filename: 'widget.js',
     publicPath: '/',
     library: 'airfill-widget',
     libraryTarget: 'umd'

--- a/config/standalone.js
+++ b/config/standalone.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const path = require('path');
+const webpack = require('webpack');
+const distConfig = require('./dist');
+
+const config = Object.assign({}, distConfig, {
+  output: {
+    path: path.join(__dirname, '/../dist'),
+    filename: 'standalone.js',
+    publicPath: '/',
+    library: 'airfill-widget',
+    libraryTarget: 'umd'
+  },
+  externals: {
+
+  }
+});
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,13 @@
     "react-test-renderer": "15.4.2",
     "url-loader": "0.5.8",
     "webpack": "3.10.0",
-    "webpack-dev-server": "2.9.7"
+    "webpack-dev-server": "2.9.7",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
+  },
+  "peerDependencies": {
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "dependencies": {
     "@bitrefill/react-pusher": "^0.1.0",
@@ -74,8 +80,6 @@
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.8",
     "pusher-js": "^4.2.2",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
     "react-redux": "^5.0.4",
     "react-router": "^4.1.2",
     "react-router-redux": "^5.0.0-alpha.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitrefill/airfill-widget",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Airfill Embeddable Refill Widget",
   "main": "dist/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "clean": "rm -rf dist/*",
     "copy": "cp -f ./src/index.html ./dist",
-    "dist": "npm run clean && npm run copy && webpack --env=dist --json > stats.json",
+    "build": "npm run clean && npm run dist && npm run standalone",
+    "dist": "webpack --env=dist --json > stats.json",
+    "standalone": "npm run copy && webpack --env=standalone --json > stats.json",
     "lint": "eslint ./src",
     "release:major": "npm version major && npm publish && git push --follow-tags",
     "release:minor": "npm version minor && npm publish && git push --follow-tags",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "start": "npm run serve",
     "test": "jest",
     "test:watch": "npm test -- --watch",
-    "webpack-stats": "webpack-bundle-analyzer stats.json"
+    "webpack-stats": "webpack-bundle-analyzer stats.json",
+    "prepublish": "npm build"
   },
   "keywords": [],
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rm -rf dist/*",
     "copy": "cp -f ./src/index.html ./dist",
-    "build": "npm run clean && npm run dist && npm run standalone",
+    "build": "npm run clean && npm run copy && webpack --env=dist && webpack --env=standalone",
     "dist": "webpack --env=dist --json > stats.json",
     "standalone": "npm run copy && webpack --env=standalone --json > stats.json",
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitrefill/airfill-widget",
   "version": "2.0.0",
   "description": "Airfill Embeddable Refill Widget",
-  "main": "dist/widget.js",
+  "main": "dist/index.js",
   "engines": {
     "node": "^8.2.0",
     "yarn": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitrefill/airfill-widget",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Airfill Embeddable Refill Widget",
   "main": "dist/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitrefill/airfill-widget",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Airfill Embeddable Refill Widget",
   "main": "dist/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -54,11 +54,15 @@
     "webpack": "3.10.0",
     "webpack-dev-server": "2.9.7",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "pusher-js": "^4.2.2",
+    "libphonenumber-js": "^0.4.32"
   },
   "peerDependencies": {
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "pusher-js": "^4.2.2",
+    "libphonenumber-js": "^0.4.32"
   },
   "dependencies": {
     "@bitrefill/react-pusher": "^0.1.0",
@@ -72,14 +76,12 @@
     "glamor": "^2.20.39",
     "history": "^4.7.2",
     "input-format": "^0.1.15",
-    "libphonenumber-js": "^0.4.32",
     "material-ui": "^1.0.0-beta.27",
     "node-sass": "^4.5.3",
     "postcss-cssnext": "^3.0.2",
     "postcss-flexbugs-fixes": "^3.2.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.8",
-    "pusher-js": "^4.2.2",
     "react-redux": "^5.0.4",
     "react-router": "^4.1.2",
     "react-router-redux": "^5.0.0-alpha.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags",
     "serve": "node server.js --env=dev",
-    "serve:dist": "node server.js --env=dist",
+    "serve:dist": "node server.js --env=standalone",
     "start": "npm run serve",
     "test": "jest",
     "test:watch": "npm test -- --watch",

--- a/src/components/Order/NewPayment.js
+++ b/src/components/Order/NewPayment.js
@@ -141,7 +141,7 @@ const NewPayment = ({
                     key={title}
                     onClick={() => callback(order)}
                     disabled={disabled}
-                    primary={i === 0}
+                    color={i === 0 ? 'primary' : 'default'}
                   >
                     {title}
                   </Button>,

--- a/src/components/Order/RefillDelivered.js
+++ b/src/components/Order/RefillDelivered.js
@@ -45,7 +45,7 @@ const RefillDelivered = ({ paymentStatus: { deliveryData = {} }, onReset }) => {
           {deliveryData.pinInfo.other}
         </p>
       )}
-      <Button raised onClick={onReset}>
+      <Button raised color="primary" onClick={onReset}>
         Send another refill
       </Button>
     </div>

--- a/src/components/Order/RefillFailed.js
+++ b/src/components/Order/RefillFailed.js
@@ -35,7 +35,7 @@ Thanks!`);
     text =
       'We have sent you an automatic refund. Please make sure your details are correct and try again!';
     action = (
-      <Button raised onClick={onReset}>
+      <Button raised color="primary" onClick={onReset}>
         Send another refill
       </Button>
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 const args = require('minimist')(process.argv.slice(2));
 
 // List of allowed environments
-const allowedEnvs = ['dev', 'dist'];
+const allowedEnvs = ['dev', 'dist', 'standalone'];
 
 // Set the correct environment
 let env;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1848,15 +1848,9 @@ ejs@^2.5.6:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
-electron-releases@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
-
 electron-to-chromium@^1.3.30:
-  version "1.3.30"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
-  dependencies:
-    electron-releases "^2.1.0"
+  version "1.3.31"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz#00d832cba9fe2358652b0c48a8816c8e3a037e9f"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -4955,8 +4949,8 @@ raw-body@2.3.2:
     unpipe "1.0.0"
 
 rc@^1.1.7:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.3.tgz#51575a900f8dd68381c710b4712c2154c3e2035b"
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.4.tgz#a0f606caae2a3b862bbd0ef85482c0125b315fa3"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -5505,8 +5499,8 @@ selfsigned@^1.9.1:
     node-forge "0.6.33"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -6113,8 +6107,8 @@ uuid@^2.0.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0, uuid@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Creates two different bundles
#### `dist/index.js` 
webpack library with
- `react`
- `react-dom`
- `libphonenumber-js`
- `pusher-js`

excluded and added as peer dependencies

This reduces bundle size to `~160kb` and no duplicate modules bundled into dashboard/widget

#### `dist/widget.js` 
Standalone widget with all dependencies bundled (~230kb gzipped)